### PR TITLE
add `published_time` meta tag for articles for medium timestamping

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
 
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta property="article:published_time" content="{{ page.date }}" />
 
   <title>
     {% if page.title %}{{ page.title | escape }} - {{ site.title | escape }}


### PR DESCRIPTION
Adds metadata for when the article was originally published for Medium to automatically pick up the publication date when importing published blogs to the DSA Medium publication.